### PR TITLE
Simpler v1 API

### DIFF
--- a/packages/api/src/dopamine/api/v1.d
+++ b/packages/api/src/dopamine/api/v1.d
@@ -28,26 +28,26 @@ struct PackageSearchEntry
 {
     string name;
     string description;
-    // numVersions and numRecipes are useful with `latestOnly` search option
+    string lastVersion;
+    string lastRecipeRev;
     uint numVersions;
     uint numRecipes;
-    PkgVersionSearchEntry[] versions;
 }
 
-struct PkgVersionSearchEntry
-{
-    @Name("version")
-    string ver;
-    PkgRecipeSearchEntry[] recipes;
-}
+// struct PkgVersionSearchEntry
+// {
+//     @Name("version")
+//     string ver;
+//     PkgRecipeSearchEntry[] recipes;
+// }
 
-struct PkgRecipeSearchEntry
-{
-    string revision;
-    @Optional
-    string createdBy;
-    SysTime created;
-}
+// struct PkgRecipeSearchEntry
+// {
+//     string revision;
+//     @Optional
+//     string createdBy;
+//     SysTime created;
+// }
 
 @Request(Method.GET, "/v1/packages/:name")
 @Response!PackageResource
@@ -75,7 +75,8 @@ struct GetPackageRecipe
     string revision;
 }
 
-/// Search packages and package recipes according a pattern and options
+/// Search packages and package recipes according a pattern and options.
+/// The packages are returned in the order of the most downloaded first.
 @Request(Method.GET, "/v1/packages")
 @Response!(PackageSearchEntry[])
 struct SearchPackages
@@ -106,18 +107,18 @@ struct SearchPackages
     @Query
     bool extended;
 
-    /// if defined, a single version and revision is returned per package
-    /// (the latest revision of the highest version)
-    @Query
-    bool latestOnly;
+    // offset and limit allows basic server-side pagination
+    // this is not perfect as the query result or package order
+    // may change between two invocations.
+    // If not acceptable, client side pagination should be performed
 
-    /// limit the number of distinct packages returned
+    /// offset of the returned packages returned
+    @Query @OmitIfInit
+    int offset;
+
+    /// limit the number of packages returned
     @Query @OmitIfInit
     int limit;
-
-    /// limit the total number of recipe entries returned.
-    @Query @OmitIfInit
-    int recLimit;
 }
 
 /+ recipes API +/

--- a/packages/api/src/dopamine/api/v1.d
+++ b/packages/api/src/dopamine/api/v1.d
@@ -10,18 +10,25 @@ struct PackageResource
 {
     string name;
     string description;
-    string[] versions;
+
+    PackageVersionResource[] versions;
 }
+
+struct PackageVersionResource
+{
+    @Name("version")
+    string ver;
+
+    PackageRecipeResource[] recipes;
+}
+
 
 /// only what is needed for dependency resolution/fetching
 struct PackageRecipeResource
 {
-    string name;
-    @Name("version") string ver;
-    string revision;
     int recipeId;
+    string revision;
     string archiveName;
-    string description;
 }
 
 struct PackageSearchEntry
@@ -34,45 +41,11 @@ struct PackageSearchEntry
     uint numRecipes;
 }
 
-// struct PkgVersionSearchEntry
-// {
-//     @Name("version")
-//     string ver;
-//     PkgRecipeSearchEntry[] recipes;
-// }
-
-// struct PkgRecipeSearchEntry
-// {
-//     string revision;
-//     @Optional
-//     string createdBy;
-//     SysTime created;
-// }
-
 @Request(Method.GET, "/v1/packages/:name")
 @Response!PackageResource
 struct GetPackage
 {
     string name;
-}
-
-@Request(Method.GET, "/v1/packages/:name/:version/latest")
-@Response!PackageRecipeResource
-struct GetPackageLatestRecipe
-{
-    string name;
-    @("version")
-    string ver;
-}
-
-@Request(Method.GET, "/v1/packages/:name/:version/:revision")
-@Response!PackageRecipeResource
-struct GetPackageRecipe
-{
-    string name;
-    @("version")
-    string ver;
-    string revision;
 }
 
 /// Search packages and package recipes according a pattern and options.
@@ -109,8 +82,8 @@ struct SearchPackages
 
     // offset and limit allows basic server-side pagination
     // this is not perfect as the query result or package order
-    // may change between two invocations.
-    // If not acceptable, client side pagination should be performed
+    // may change between one page to the next.
+    // If not acceptable, client side pagination should be preferred.
 
     /// offset of the returned packages returned
     @Query @OmitIfInit
@@ -126,24 +99,37 @@ struct SearchPackages
 /// Recipe resource
 struct RecipeResource
 {
+    /// Identifier of the recipe on the registry
     int id;
-    string packName;
 
+    /// Name of the package
+    string name;
+
+    /// Identifier of the user who published the recipe
     int createdBy;
+    /// Date/time of publication of this recipe
     SysTime created;
 
+    /// Version of this package (Semver compliant)
     @Name("version") string ver;
+    /// Revision of this recipe
     string revision;
 
+    /// Archive name of this recipe. Can be used to build a download URL
     string archiveName;
 
+    /// Description of the package (as written in the recipe)
     string description;
+    /// Upstream URL of the package (as written in the recipe)
     string upstreamUrl;
+    /// License of the package (as written in the recipe)
     string license;
 
+    /// Recipe file content (aka. dopamine.lua)
     string recipe;
-    /// mime type of readme
+    /// Mime type of ReadMe file (if any)
     string readmeMt;
+    /// Content of the ReadMe file (if any)
     string readme;
 }
 
@@ -157,7 +143,6 @@ struct GetRecipe
 struct NewRecipeResp
 {
     @Name("new") string new_; // "package", "version" or ""
-    @Name("package") PackageResource pkg;
     RecipeResource recipe;
     string uploadBearerToken;
 }

--- a/packages/client/src/dopamine/client/publish.d
+++ b/packages/client/src/dopamine/client/publish.d
@@ -236,20 +236,19 @@ int publishMain(string[] args)
 
     NewRecipeResp newRecResp = resp.payload;
 
-    const pkg = newRecResp.pkg;
     const rec = newRecResp.recipe;
     const sha256 = Base64.encode(dig.finish()[]).idup;
 
     switch (newRecResp.new_)
     {
         case "package":
-            logInfo("Publish: New package - %s/%s", info(pkg.name), info(rec.ver));
+            logInfo("Publish: New package - %s/%s", info(rec.name), info(rec.ver));
             break;
         case "version":
-            logInfo("Publish: Adding version %s to package %s", info(rec.ver), info(pkg.name));
+            logInfo("Publish: Adding version %s to package %s", info(rec.ver), info(rec.name));
             break;
         case "":
-            logInfo("Publish: Adding new revision to %s/%s", info(pkg.name), info(rec.ver));
+            logInfo("Publish: Adding new revision to %s/%s", info(rec.name), info(rec.ver));
             break;
         default:
             debug assert(false, "unknown new_ field value");
@@ -259,7 +258,7 @@ int publishMain(string[] args)
     logInfo("Uploading archive and checking archive...");
     registry.uploadArchive(newRecResp.uploadBearerToken, archivePath, sha256);
 
-    logInfo("Publish: %s - %s/%s/%s", success("OK"), info(pkg.name), info(rec.ver), rec
+    logInfo("Publish: %s - %s/%s/%s", success("OK"), info(rec.name), info(rec.ver), rec
             .revision);
     return 0;
 }

--- a/packages/lib/src/dopamine/dep/source.d
+++ b/packages/lib/src/dopamine/dep/source.d
@@ -251,22 +251,20 @@ final class DopRegistryDepSource : DepSource
     Semver[] depAvailVersions(string name) @safe
     {
         auto pack = packagePayload(name);
-        return pack.versions.map!(v => Semver(v)).array;
+        return pack.versions.map!(v => Semver(v.ver)).array;
     }
 
     bool hasPackage(string name, Semver ver, string revision) @safe
     {
+        auto pack = packagePayload(name);
+        auto packVer = pack.versions.find!(v => v.ver == ver.toString());
+        if (!packVer.length)
+            return false;
+
         if (revision)
-        {
-            auto req = GetPackageRecipe(name, ver.toString(), revision);
-            auto resp = _registry.sendRequest(req);
-            return resp.code < 400;
-        }
-        else {
-            auto req = GetPackageLatestRecipe(name, ver.toString());
-            auto resp = _registry.sendRequest(req);
-            return resp.code < 400;
-        }
+            return (packVer[0].recipes.find!(r => r.revision == revision)).length != 0;
+        else
+            return true;
     }
 
     RecipeDir depRecipe(string name, Semver ver, string revision = null) @system

--- a/packages/lib/src/dopamine/registry.d
+++ b/packages/lib/src/dopamine/registry.d
@@ -680,15 +680,6 @@ unittest
     requestResource(GetPackage("pkga"))
         .shouldEqual(apiPrefix ~ "/v1/packages/pkga");
 
-    requestResource(GetPackageLatestRecipe("pkga", "1.0.0"))
-        .shouldEqual(apiPrefix ~ "/v1/packages/pkga/1.0.0/latest");
-
-    requestResource(GetPackageRecipe("pkga", "1.0.0", "somerev"))
-        .shouldEqual(apiPrefix ~ "/v1/packages/pkga/1.0.0/somerev");
-
-    requestResource(GetPackageRecipe("pkga", "1.0.0", null))
-        .shouldThrow();
-
-    requestResource(SearchPackages("pat", false, true, false, true, true, 12))
-        .shouldEqual(apiPrefix ~ "/v1/packages?q=pat&cs&extended&latestOnly&limit=12");
+    requestResource(SearchPackages("pat", false, true, false, true, 0, 12))
+        .shouldEqual(apiPrefix ~ "/v1/packages?q=pat&cs&extended&limit=12");
 }

--- a/packages/pgd/src/pgd/conn.d
+++ b/packages/pgd/src/pgd/conn.d
@@ -422,7 +422,11 @@ class PgConn
         return rows;
     }
 
-    auto getRowByRow(R)() @trusted if (isRow!R)
+    /// Returns a D range of `R`, each element being a row
+    /// fetched in the single row mode of PostgreSQL.
+    /// A reference to the connection is in the returned object,
+    /// which should not leave the scope of `this`.
+    auto getRowByRow(R)() return scope @trusted if (isRow!R)
     {
         scope(exit)
             lastSql = null;

--- a/packages/registry/src/dopamine/registry/test.d
+++ b/packages/registry/src/dopamine/registry/test.d
@@ -7,6 +7,7 @@ version (unittest)
     import pgd.conn;
     import pgd.connstring;
 
+    import core.sync.mutex;
     import std.datetime;
     import std.format;
     import std.process;
@@ -21,6 +22,8 @@ version (unittest)
     {
         return environment.get("PGD_TEST_DB", "postgres:///dop-registry-test");
     }
+
+    shared Mutex registryMutex;
 
     shared static this()
     {
@@ -57,6 +60,8 @@ version (unittest)
             db.exec(import("2.semver.sql"));
             db.exec(import("v1.sql"));
         }
+
+        registryMutex = new shared Mutex();
     }
 
     struct TestUser
@@ -97,228 +102,228 @@ version (unittest)
         string license;
     }
 
+    struct RevInsert
+    {
+        string rev;
+        string createdBy;
+        Date created;
+        uint counter;
+    }
+
+    struct VerInsert
+    {
+        string ver;
+        RevInsert[] revs;
+    }
+
+    struct PkgInsert
+    {
+        string name;
+        string description;
+        string license;
+        VerInsert[] versions;
+    }
+
+    const registryInserts = [
+        PkgInsert(
+            "pkga", "The Package A", "MIT", [
+                VerInsert(
+                    "0.1.0", [
+                        RevInsert("123456", "one", Date(2020, 2, 12), 1250),
+                    ]
+                ),
+                VerInsert(
+                    "0.2.0", [
+                        RevInsert("123456", "one", Date(2020, 4, 12), 123),
+                        RevInsert("654321", "two", Date(2021, 3, 1), 1520),
+                    ]
+                ),
+            ]
+        ),
+        PkgInsert(
+            "libincredible", "An incredible library", "Boost", [
+                VerInsert(
+                    "1.0.0", [
+                        RevInsert("123456", "one", Date(2021, 2, 12), 50_210),
+                        RevInsert("654321", "one", Date(2022, 5, 18), 1203),
+                    ]
+                ),
+                VerInsert(
+                    "1.2.0-beta.0", [
+                        RevInsert("123456", "one", Date(2022, 3, 12), 123),
+                    ]
+                ),
+                VerInsert(
+                    "1.2.0-beta.1", [
+                        RevInsert("123456", "one", Date(2022, 3, 18), 1233),
+                    ]
+                ),
+                VerInsert(
+                    "1.2.0", [
+                        RevInsert("123456", "one", Date(2022, 4, 12), 798),
+                        RevInsert("654321", "one", Date(2022, 5, 1), 12_450),
+                    ]
+                ),
+            ]
+        ),
+        PkgInsert(
+            "uselesslib", "A useless library", "Boost", [
+                VerInsert(
+                    "0.0.1", [
+                        RevInsert("123456", "three", Date(2021, 2, 12), 12),
+                        RevInsert("654321", "three", Date(2022, 5, 18), 21),
+                    ]
+                ),
+                VerInsert(
+                    "0.0.2-beta.1", [
+                        RevInsert("123456", "three", Date(2022, 3, 12), 13),
+                    ]
+                ),
+                VerInsert(
+                    "0.0.2-beta.2", [
+                        RevInsert("123456", "three", Date(2022, 3, 18), 2),
+                    ]
+                ),
+                VerInsert(
+                    "0.0.2-beta.3", [
+                        RevInsert("123456", "three", Date(2022, 3, 18), 3),
+                    ]
+                ),
+                VerInsert(
+                    "0.0.2", [
+                        RevInsert("abcdef", "three", Date(2022, 3, 18), 2),
+                        RevInsert("123456", "three", Date(2022, 3, 19), 3),
+                        RevInsert("654321", "three", Date(2022, 3, 20), 1),
+                        RevInsert("fedcba", "three", Date(2022, 3, 21), 21),
+                    ]
+                ),
+            ]
+        ),
+        PkgInsert(
+            "pkgb", "The Package B", "MIT", [
+                VerInsert(
+                    "0.1.0", [
+                        RevInsert("123456", "one", Date(2020, 2, 12), 450),
+                    ]
+                ),
+                VerInsert(
+                    "0.2.0", [
+                        RevInsert("123456", "one", Date(2020, 4, 12), 38),
+                        RevInsert("654321", "two", Date(2021, 3, 1), 512),
+                    ]
+                ),
+            ]
+        ),
+        PkgInsert(
+            "http-over-ftp", "The nonsense networking library", "Boost", [
+                VerInsert(
+                    "0.0.1", [
+                        RevInsert("123456", "three", Date(2021, 2, 12), 0),
+                        RevInsert("654321", "three", Date(2022, 5, 18), 1),
+                    ]
+                ),
+                VerInsert(
+                    "0.0.2-beta.1", [
+                        RevInsert("123456", "three", Date(2022, 3, 12), 2),
+                    ]
+                ),
+                VerInsert(
+                    "0.0.2-beta.2", [
+                        RevInsert("123456", "three", Date(2022, 3, 18), 1),
+                    ]
+                ),
+                VerInsert(
+                    "0.0.2-beta.3", [
+                        RevInsert("123456", "three", Date(2022, 3, 18), 1),
+                    ]
+                ),
+                VerInsert(
+                    "0.0.2", [
+                        RevInsert("abcdef", "three", Date(2022, 3, 18), 1),
+                        RevInsert("123456", "three", Date(2022, 3, 19), 0),
+                        RevInsert("654321", "three", Date(2022, 3, 20), 0),
+                        RevInsert("fedcba", "three", Date(2022, 3, 21), 5),
+                    ]
+                ),
+            ]
+        ),
+        PkgInsert(
+            "libcurl", "The ubiquitous networking library", "Boost", [
+                VerInsert(
+                    "7.68.0", [
+                        RevInsert("123456", "one", Date(2021, 2, 12), 798),
+                        RevInsert("654321", "one", Date(2021, 5, 18), 1212),
+                    ]
+                ),
+                VerInsert(
+                    "7.84.0", [
+                        RevInsert("123456", "one", Date(2022, 3, 12), 109),
+                        RevInsert("654321", "two", Date(2022, 5, 18), 12_493),
+                    ]
+                ),
+            ]
+        ),
+    ];
+
     struct TestRegistry
     {
+        DbClient client;
         TestUser[string] users;
         TestPkg[string] pkgs;
         TestArchive[string] archives;
         TestRecipe[string] recipes;
-    }
 
-    TestRegistry populateTestRegistry(DbClient client)
-    {
-        static struct RevInsert
+        this(DbClient client)
         {
-            string rev;
-            string createdBy;
-            Date created;
-            uint counter;
-        }
+            this.client = client;
+            registryMutex.lock();
 
-        static struct VerInsert
-        {
-            string ver;
-            RevInsert[] revs;
-        }
-
-        static struct PkgInsert
-        {
-            string name;
-            string description;
-            string license;
-            VerInsert[] versions;
-        }
-
-        const inserts = [
-            PkgInsert(
-                "pkga", "The Package A", "MIT", [
-                    VerInsert(
-                        "0.1.0", [
-                            RevInsert("123456", "one", Date(2020, 2, 12), 1250),
-                        ]
-                    ),
-                    VerInsert(
-                        "0.2.0", [
-                            RevInsert("123456", "one", Date(2020, 4, 12), 123),
-                            RevInsert("654321", "two", Date(2021, 3, 1), 1520),
-                        ]
-                    ),
-                ]
-            ),
-            PkgInsert(
-                "libincredible", "An incredible library", "Boost", [
-                    VerInsert(
-                        "1.0.0", [
-                            RevInsert("123456", "one", Date(2021, 2, 12), 50_210),
-                            RevInsert("654321", "one", Date(2022, 5, 18), 1203),
-                        ]
-                    ),
-                    VerInsert(
-                        "1.2.0-beta.0", [
-                            RevInsert("123456", "one", Date(2022, 3, 12), 123),
-                        ]
-                    ),
-                    VerInsert(
-                        "1.2.0-beta.1", [
-                            RevInsert("123456", "one", Date(2022, 3, 18), 1233),
-                        ]
-                    ),
-                    VerInsert(
-                        "1.2.0", [
-                            RevInsert("123456", "one", Date(2022, 4, 12), 798),
-                            RevInsert("654321", "one", Date(2022, 5, 1), 12_450),
-                        ]
-                    ),
-                ]
-            ),
-            PkgInsert(
-                "uselesslib", "A useless library", "Boost", [
-                    VerInsert(
-                        "0.0.1", [
-                            RevInsert("123456", "three", Date(2021, 2, 12), 12),
-                            RevInsert("654321", "three", Date(2022, 5, 18), 21),
-                        ]
-                    ),
-                    VerInsert(
-                        "0.0.2-beta.1", [
-                            RevInsert("123456", "three", Date(2022, 3, 12), 13),
-                        ]
-                    ),
-                    VerInsert(
-                        "0.0.2-beta.2", [
-                            RevInsert("123456", "three", Date(2022, 3, 18), 2),
-                        ]
-                    ),
-                    VerInsert(
-                        "0.0.2-beta.3", [
-                            RevInsert("123456", "three", Date(2022, 3, 18), 3),
-                        ]
-                    ),
-                    VerInsert(
-                        "0.0.2", [
-                            RevInsert("abcdef", "three", Date(2022, 3, 18), 2),
-                            RevInsert("123456", "three", Date(2022, 3, 19), 3),
-                            RevInsert("654321", "three", Date(2022, 3, 20), 1),
-                            RevInsert("fedcba", "three", Date(2022, 3, 21), 21),
-                        ]
-                    ),
-                ]
-            ),
-            PkgInsert(
-                "pkgb", "The Package B", "MIT", [
-                    VerInsert(
-                        "0.1.0", [
-                            RevInsert("123456", "one", Date(2020, 2, 12), 450),
-                        ]
-                    ),
-                    VerInsert(
-                        "0.2.0", [
-                            RevInsert("123456", "one", Date(2020, 4, 12), 38),
-                            RevInsert("654321", "two", Date(2021, 3, 1), 512),
-                        ]
-                    ),
-                ]
-            ),
-            PkgInsert(
-                "http-over-ftp", "The nonsense networking library", "Boost", [
-                    VerInsert(
-                        "0.0.1", [
-                            RevInsert("123456", "three", Date(2021, 2, 12), 0),
-                            RevInsert("654321", "three", Date(2022, 5, 18), 1),
-                        ]
-                    ),
-                    VerInsert(
-                        "0.0.2-beta.1", [
-                            RevInsert("123456", "three", Date(2022, 3, 12), 2),
-                        ]
-                    ),
-                    VerInsert(
-                        "0.0.2-beta.2", [
-                            RevInsert("123456", "three", Date(2022, 3, 18), 1),
-                        ]
-                    ),
-                    VerInsert(
-                        "0.0.2-beta.3", [
-                            RevInsert("123456", "three", Date(2022, 3, 18), 1),
-                        ]
-                    ),
-                    VerInsert(
-                        "0.0.2", [
-                            RevInsert("abcdef", "three", Date(2022, 3, 18), 1),
-                            RevInsert("123456", "three", Date(2022, 3, 19), 0),
-                            RevInsert("654321", "three", Date(2022, 3, 20), 0),
-                            RevInsert("fedcba", "three", Date(2022, 3, 21), 5),
-                        ]
-                    ),
-                ]
-            ),
-            PkgInsert(
-                "libcurl", "The ubiquitous networking library", "Boost", [
-                    VerInsert(
-                        "7.68.0", [
-                            RevInsert("123456", "one", Date(2021, 2, 12), 798),
-                            RevInsert("654321", "one", Date(2021, 5, 18), 1212),
-                        ]
-                    ),
-                    VerInsert(
-                        "7.84.0", [
-                            RevInsert("123456", "one", Date(2022, 3, 12), 109),
-                            RevInsert("654321", "two", Date(2022, 5, 18), 12_493),
-                        ]
-                    ),
-                ]
-            ),
-        ];
-
-        return client.transac((scope db) {
-
-            TestRegistry registry;
-
-            foreach (pkg; inserts)
-            {
-                registry.pkgs[pkg.name] = db.execRow!TestPkg(
-                    `
-                        INSERT INTO package (name, description) VALUES ($1, $2)
-                        RETURNING name, description
-                    `,
-                    pkg.name, pkg.description
-                );
-
-                foreach (ver; pkg.versions)
+            client.transac((scope db) {
+                foreach (pkg; registryInserts)
                 {
-                    foreach (rev; ver.revs)
+                    this.pkgs[pkg.name] = db.execRow!TestPkg(
+                        `
+                            INSERT INTO package (name, description) VALUES ($1, $2)
+                            RETURNING name, description
+                        `,
+                        pkg.name, pkg.description
+                    );
+
+                    foreach (ver; pkg.versions)
                     {
-                        if (!(rev.createdBy in registry.users))
+                        foreach (rev; ver.revs)
                         {
-                            const email = format!`user.%s@dop.test`(rev.createdBy);
-                            const name = format!`User %s`(rev.createdBy.capitalize());
-                            registry.users[rev.createdBy] = db.execRow!TestUser(
-                                `
+                            if (!(rev.createdBy in this.users))
+                            {
+                                const email = format!`user.%s@dop.test`(rev.createdBy);
+                                const name = format!`User %s`(rev.createdBy.capitalize());
+                                this.users[rev.createdBy] = db.execRow!TestUser(
+                                    `
                                     INSERT INTO "user"(email, name) VALUES($1, $2)
                                     RETURNING id, email, name
                                 `, email, name
-                            );
-                        }
+                                );
+                            }
 
-                        const key = format!"%s/%s/%s"(pkg.name, ver.ver, rev.rev);
-                        const createdBy = registry.users[rev.createdBy].id;
-                        const created = SysTime(rev.created, UTC());
-                        const upstreamUrl = format!"https://%s.test"(pkg.name);
-                        const archiveName = format!"%s-%s-%s.tar.xz"(pkg.name, ver.ver, rev.rev);
-                        const archiveData = cast(immutable(ubyte)[]) archiveName;
+                            const key = format!"%s/%s/%s"(pkg.name, ver.ver, rev.rev);
+                            const createdBy = this.users[rev.createdBy].id;
+                            const created = SysTime(rev.created, UTC());
+                            const upstreamUrl = format!"https://%s.test"(pkg.name);
+                            const archiveName = format!"%s-%s-%s.tar.xz"(pkg.name, ver.ver, rev.rev);
+                            const archiveData = cast(immutable(ubyte)[]) archiveName;
 
-                        registry.archives[archiveName] = db.execRow!TestArchive(
-                            `
+                            this.archives[archiveName] = db.execRow!TestArchive(
+                                `
                                 INSERT INTO archive (name, created, created_by, counter, upload_done, data)
                                 VALUES($1, $2, $3, $4, TRUE, $5)
                                 RETURNING id, name, created, created_by, data
                             `, archiveName, created, createdBy, rev.counter, archiveData
-                        );
+                            );
 
-                        const archiveId = registry.archives[archiveName].id;
+                            const archiveId = this.archives[archiveName].id;
 
-                        registry.recipes[key] = db.execRow!TestRecipe(
-                            `
+                            this.recipes[key] = db.execRow!TestRecipe(
+                                `
                                 INSERT INTO recipe (
                                     package_name, created_by, created, version, revision, archive_id,
                                     description, upstream_url, license
@@ -329,22 +334,24 @@ version (unittest)
                                     package_name, created_by, created, version, revision, archive_id,
                                     description, upstream_url, license
                             `, pkg.name, createdBy, created, ver.ver, rev.rev, archiveId, pkg.description,
-                            upstreamUrl, pkg.license
-                        );
+                                upstreamUrl, pkg.license
+                            );
+                        }
                     }
                 }
-            }
-            return registry;
-        });
-    }
+            });
+        }
 
-    void cleanTestRegistry(DbClient client)
-    {
-        client.transac((scope db) {
-            db.exec(`DELETE FROM "recipe"`);
-            db.exec(`DELETE FROM "package"`);
-            db.exec(`DELETE FROM "archive"`);
-            db.exec(`DELETE FROM "user"`);
-        });
+        ~this()
+        {
+            client.transac((scope db) {
+                db.exec(`DELETE FROM "recipe"`);
+                db.exec(`DELETE FROM "package"`);
+                db.exec(`DELETE FROM "archive"`);
+                db.exec(`DELETE FROM "user"`);
+            });
+
+            registryMutex.unlock();
+        }
     }
 }

--- a/packages/registry/src/dopamine/registry/v1/package.d
+++ b/packages/registry/src/dopamine/registry/v1/package.d
@@ -21,9 +21,8 @@ struct V1Api
 
 V1Api v1Api(DbClient client, ArchiveManager archiveMgr)
 {
-    auto pkg = new PackagesApi(client);
     return V1Api(
-        pkg,
-        new RecipesApi(client, archiveMgr, pkg),
+        new PackagesApi(client),
+        new RecipesApi(client, archiveMgr),
     );
 }

--- a/tests_e2e/tests/search.test
+++ b/tests_e2e/tests/search.test
@@ -3,8 +3,5 @@ RECIPE=notarecipe
 REGISTRY=base
 
 CMD=$DOP search --all
-EXPECT_MATCH=pkga\s+Description of pkga
-EXPECT_MATCH=2 versions\s+2 recipe revisions
-EXPECT_MATCH=1.0.0\s+1
-EXPECT_MATCH=2.0.0\s+1
-EXPECT_MATCH=pkgb\s+Description of pkgb
+EXPECT_MATCH=pkga/2.0.0\s+Description of pkga
+EXPECT_MATCH=pkgb/2.0.0\s+Description of pkgb


### PR DESCRIPTION
V1 is now simpler and more consistent:
 - `GET /v1/packages` (search) returns only flat data: name, description and info about last version/revision of found packages
 - `GET /v1/packages/:name` returns all versions and available recipes and archive name, but no detail about recipe content
 - `GET /v1/packages/:name/:version/latest` and `/v1/packages/:name/:version/:revision` are obsolete. (needed detail is available in `GET /v1/packages/:name`)
 - `POST /v1/recipes` do not return the full package, but only the posted recipe
 - `GET /v1/recipes/:id` is unchanged